### PR TITLE
v3.1.2: Fix fill-in-blank multiple acceptable answers

### DIFF
--- a/src/answerOverlay.js
+++ b/src/answerOverlay.js
@@ -96,11 +96,19 @@ function highlighter() {
         let answerElements = document.getElementsByClassName("correct-answers");
         let answers = [];
         if (answerElements.length != 0) {
+            // Each .correct-answers is one blank, may have multiple acceptable .correct-answer spans
             for (let x = 0; x < answerElements.length; x++) {
-                const el = answerElements[x].getElementsByClassName("correct-answer")[0];
-                if (el) {
-                    // Preserve full answer text, just trim whitespace
-                    const text = el.textContent.trim();
+                const correctAnswerEls = answerElements[x].getElementsByClassName("correct-answer");
+                if (correctAnswerEls.length > 0) {
+                    // Take the first acceptable answer
+                    let text = correctAnswerEls[0].textContent;
+                    // Remove separator span content if present
+                    const separator = correctAnswerEls[0].querySelector(".separator");
+                    if (separator) {
+                        text = text.replace(separator.textContent, "");
+                    }
+                    // Clean trailing punctuation
+                    text = text.replace(/[,\s]+$/, "").trim();
                     if (text) {
                         answers.push(text);
                     }

--- a/src/contentSolver.js
+++ b/src/contentSolver.js
@@ -328,13 +328,27 @@ async function selectCorrectResponse(question, responses, responseElements) {
     let answers = [];
 
     if (isFillInBlankQuestion) {
-      let answerElements = document.getElementsByClassName("correct-answers");
-      console.log("S: Found", answerElements.length, "correct-answers elements");
-      for (let x = 0; x < answerElements.length; x++) {
-        const correctAnswerEl = answerElements[x].querySelector(".correct-answer");
-        if (correctAnswerEl) {
-          // Get the text content and trim, but preserve the full answer
-          const text = correctAnswerEl.textContent.trim();
+      // Each .correct-answers element corresponds to one blank
+      // Each can have MULTIPLE .correct-answer spans (acceptable alternatives)
+      let answerContainers = document.getElementsByClassName("correct-answers");
+      console.log("S: Found", answerContainers.length, "correct-answers containers (blanks)");
+
+      for (let x = 0; x < answerContainers.length; x++) {
+        // Get ALL acceptable answers for this blank
+        const correctAnswerEls = answerContainers[x].querySelectorAll(".correct-answer");
+        console.log("S: Blank", x, "has", correctAnswerEls.length, "acceptable answers");
+
+        if (correctAnswerEls.length > 0) {
+          // Take the first acceptable answer (they're all valid, just pick one)
+          // Clean up: remove trailing commas, "or", and extra whitespace
+          let text = correctAnswerEls[0].textContent;
+          // Remove nested separator spans content
+          const separator = correctAnswerEls[0].querySelector(".separator");
+          if (separator) {
+            text = text.replace(separator.textContent, "");
+          }
+          // Clean trailing punctuation and whitespace
+          text = text.replace(/[,\s]+$/, "").trim();
           console.log("S: Fill-in-blank answer", x, ":", text);
           if (text) {
             answers.push(text);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,7 +25,7 @@
     "*://learning.mheducation.com/*",
     "https://api.github.com/*"
   ],
-  "version": "3.1.1",
+  "version": "3.1.2",
   "web_accessible_resources": [
     {
       "resources": ["contentSolver.js"],


### PR DESCRIPTION
## Problem

Fill-in-the-blank questions can have **multiple acceptable answers**. The DOM structure looks like:

```html
<li class="correct-answers">
  <span class="blank-label">Field 1: </span>
  <span class="correct-answer">nondisjunction, </span>
  <span class="correct-answer">non-disjunction, </span>
  <span class="correct-answer">nondisjunctions, <span class="separator"> or </span></span>
  <span class="correct-answer">non-disjunctions</span>
</li>
```

The old code only grabbed the **first** `.correct-answer` using `querySelector()`, but also didn't handle:
- Trailing commas on answers
- Nested `.separator` spans containing " or "

## Fix

- Use `querySelectorAll(".correct-answer")` to get all acceptable answers
- Take the first acceptable answer (they're all valid)
- Remove `.separator` span content before extracting text
- Strip trailing commas and whitespace with `.replace(/[,\s]+$/, "")`

## Files Changed

- `src/contentSolver.js` — Fixed answer extraction logic
- `src/answerOverlay.js` — Same fix
- `src/manifest.json` — Version bump to 3.1.2